### PR TITLE
Improve loadbalancer cleanup

### DIFF
--- a/lib/charms/layer/azure.py
+++ b/lib/charms/layer/azure.py
@@ -382,9 +382,9 @@ def create_loadbalancer(request):
             "--lb-name",
             lb_name,
             "--frontend-port",
-            str(front),
+            front,
             "--backend-port",
-            str(back),
+            back,
             "--protocol",
             request.protocol.value.capitalize(),
         )
@@ -407,7 +407,7 @@ def create_loadbalancer(request):
             "--interval",
             health_check.interval,
             "--threshold",
-            health_check.get("retries"),
+            health_check.retries,
         ]
 
         if health_check.path:
@@ -645,7 +645,7 @@ def _azure(cmd, *args, return_stderr=False):
     Call the azure-cli tool.
     """
     cmd = ["az", cmd]
-    cmd.extend(args)
+    cmd.extend(str(arg) for arg in args)
     result = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     stdout = result.stdout.decode("utf8").strip()
     stderr = result.stderr.decode("utf8").strip()

--- a/tox.ini
+++ b/tox.ini
@@ -16,3 +16,6 @@ commands = pytest --tb native -s {posargs}
 [testenv:lint]
 envdir = {toxworkdir}/py3
 commands = flake8 {toxinidir}/lib {toxinidir}/reactive {toxinidir}/tests
+
+[flake8]
+max-line-length = 88

--- a/wheelhouse.txt
+++ b/wheelhouse.txt
@@ -1,1 +1,1 @@
-git+https://github.com/juju-solutions/loadbalancer-interface.git#egg=loadbalancer-interface
+loadbalancer-interface


### PR DESCRIPTION
It actually wasn't cleaning anything up even on a removed relation. This adds explicit cleanup when requests are removed, RG cleanup during the stop hook, and tags any taggable things with the Juju model tag so that they can potentially be cleaned up by Juju if they get missed.