### PR TITLE
Use model's resource group for LBs

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -51,9 +51,8 @@ options:
       sources.list(5), or in the form ppa:<user>/<ppa-name> for adding
       Personal Package Archives, or a distribution component to enable.
     type: string
-    # TODO: make series dynamic, see: https://bugs.launchpad.net/layer-apt/+bug/1796993
     default: |
-      - deb https://packages.microsoft.com/repos/azure-cli/ xenial main
+      - deb https://packages.microsoft.com/repos/azure-cli/ {series} main
   install_keys:
     description: >
       List of signing keys for install_sources package sources, per

--- a/lib/charms/layer/azure.py
+++ b/lib/charms/layer/azure.py
@@ -285,23 +285,9 @@ def create_loadbalancer(request):
     """
     _validate_loadbalancer_request(request)
 
-    resource_group = "{}-lb".format(_get_resource_group())
-    resource_group_location = _azure("group", "show", "--name", resource_group).get(
-        "location"
-    )
+    resource_group = _get_resource_group()
 
     model_tag = "juju-model-uuid=" + MODEL_UUID
-
-    _azure(
-        "group",
-        "create",
-        "--name",
-        resource_group,
-        "--location",
-        resource_group_location,
-        "--tags",
-        model_tag,
-    )
 
     lb_name = _lb_name(request)
     lb_pip_name = lb_name + "-public-ip"
@@ -464,23 +450,6 @@ def remove_loadbalancer(request):
             _azure(*command)
         except DoesNotExistAzureError:
             pass
-
-
-def remove_loadbalancer_group():
-    """
-    Remove the entire resource group for LBs.
-
-    This will clean up anything still in that group, as well.
-
-    :return: None
-    """
-    resource_group = "{}-lb".format(_get_resource_group())
-
-    try:
-        _azure("group", "delete", "--name", resource_group, "-y")
-        hookenv.log("Resource group {} removed".format(resource_group), hookenv.INFO)
-    except DoesNotExistAzureError:
-        pass
 
 
 def enable_loadbalancer_management(request):

--- a/lib/charms/layer/azure.py
+++ b/lib/charms/layer/azure.py
@@ -421,9 +421,10 @@ def remove_loadbalancer(request):
 
     :return: None
     """
-    resource_group = "{}-lb".format(_get_resource_group())
+    resource_group = _get_resource_group()
     # NB: Deleting the LB itself deletes any resources directly associated with it.
     lb_name = _lb_name(request)
+    # However, the public IP isn't directly associated with the LB.
     lb_pip_name = lb_name + "-public-ip"
     commands = [
         (

--- a/reactive/azure.py
+++ b/reactive/azure.py
@@ -116,7 +116,9 @@ def manage_lbs():
 
 @hook("stop")
 def cleanup():
-    layer.azure.remove_loadbalancer_group()
+    lb_consumers = endpoint_from_name("lb-consumers")
+    for request in lb_consumers.all_requests + lb_consumers.removed_requests:
+        layer.azure.remove_loadbalancer(request)
 
 
 @hook("upgrade-charm")

--- a/reactive/azure.py
+++ b/reactive/azure.py
@@ -117,6 +117,8 @@ def manage_lbs():
 @hook("stop")
 def cleanup():
     lb_consumers = endpoint_from_name("lb-consumers")
+    # These are expected to both always be empty lists (since the relations should have
+    # already been removed by this point), but we do this anyway JIC.
     for request in lb_consumers.all_requests + lb_consumers.removed_requests:
         layer.azure.remove_loadbalancer(request)
 


### PR DESCRIPTION
Since [removing a RG removes all resources it contains][doc], use the RG that Juju manages for the model rather than creating a bespoke one. That way, when the model is cleaned up, all LB resources will be cleaned up along with it as well.

Drive-by: Fix hard-coded series in `install_source` config.

[doc]: https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/delete-resource-grouphttps://docs.microsoft.com/en-us/azure/azure-resource-manager/management/delete-resource-group