### PR TITLE
Refactor integration test to align with pytest-operator changes

### DIFF
--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [3.5, 3.6, 3.7, 3.8]
+        python: [3.6, 3.7, 3.8]
 
     steps:
       - uses: actions/checkout@v2

--- a/tox.ini
+++ b/tox.ini
@@ -27,11 +27,7 @@ deps =
     # Until 2.8.6 is released
     https://github.com/juju/python-libjuju/archive/master.zip#egg=juju
     pytest
-    # Until PR #10 lands
-    https://github.com/charmed-kubernetes/pytest-operator/archive/johnsca/remove-unittest.zip#egg=pytest-operator
     pytest-operator
-    # Until PR #12 lands
-    https://github.com/juju-solutions/loadbalancer-interface/archive/johnsca/pytest-operator-refactor.zip#egg=loadbalancer-interface
     loadbalancer-interface
     requests
     ipdb

--- a/tox.ini
+++ b/tox.ini
@@ -27,9 +27,13 @@ deps =
     # Until 2.8.6 is released
     https://github.com/juju/python-libjuju/archive/master.zip#egg=juju
     pytest
-    file:///home/johnsca/juju/libs/loadbalancer-interface/dist/loadbalancer_interface-1.0.7.tar.gz#egg=loadbalancer-interface
+    # Until PR #10 lands
+    https://github.com/charmed-kubernetes/pytest-operator/archive/johnsca/remove-unittest.zip#egg=pytest-operator
     pytest-operator
+    # Until PR #12 lands
+    https://github.com/juju-solutions/loadbalancer-interface/archive/johnsca/pytest-operator-refactor.zip#egg=loadbalancer-interface
     loadbalancer-interface
+    requests
     ipdb
 commands = pytest --show-capture=no --log-cli-level=INFO --disable-warnings -svv --tb native {posargs} tests/integration
 


### PR DESCRIPTION
Changes to the integration test to align with the changes to pytest-operator in [PR #10][] and loadbalancer-interface in [PR #12][].

Also adds a connectivity test for the load balancer, which currently fails due to the issue with the address not being provided.

[PR #10]: https://github.com/charmed-kubernetes/pytest-operator/pull/10
[PR #12]: https://github.com/juju-solutions/loadbalancer-interface/pull/12