### PR TITLE
A change in the az CLI has forces this change to assign_role

### DIFF
--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -15,4 +15,4 @@ jobs:
     needs:
       - call-inclusive-naming-check
     with:
-      python: "['3.6', '3.7', '3.8', '3.9', '3.10']"
+      python: "['3.8', '3.9', '3.10', '3.11']"

--- a/lib/charms/layer/azure.py
+++ b/lib/charms/layer/azure.py
@@ -867,6 +867,9 @@ def _assign_role(request, role, resource_group=None):
     rg = request.resource_group
     if resource_group is not None:
         rg = resource_group
+    sub_id = kv().get("charm.azure.sub-id")
+    scope = f"/subscriptions/{sub_id}/resourceGroups/{rg}"
+
     try:
         _azure(
             "role",
@@ -874,8 +877,8 @@ def _assign_role(request, role, resource_group=None):
             "create",
             "--assignee-object-id",
             msi,
-            "--resource-group",
-            rg,
+            "--scope",
+            scope,
             "--role",
             role,
         )

--- a/wheelhouse.txt
+++ b/wheelhouse.txt
@@ -1,2 +1,1 @@
 loadbalancer-interface
-sniffio<1.3.1  # 1.3.1 requires setuptools>=64

--- a/wheelhouse.txt
+++ b/wheelhouse.txt
@@ -1,1 +1,2 @@
 loadbalancer-interface
+sniffio<1.3.1  # 1.3.1 requires setuptools>=64


### PR DESCRIPTION
Assign role may no longer be called with `--resource-group` but instead must include a `--scope` which includes the subscription-id and the resource-group together

https://learn.microsoft.com/en-us/cli/azure/role/assignment?view=azure-cli-latest#az-role-assignment-create